### PR TITLE
Add a Dockerfile with Python3.6

### DIFF
--- a/Dockerfile.36
+++ b/Dockerfile.36
@@ -1,0 +1,26 @@
+#FROM registry.opensource.zalan.do/stups/ubuntu:UPSTREAM
+FROM registry.opensource.zalan.do/stups/ubuntu:16.04-cd33
+MAINTAINER Zalando SE
+
+# Install python3.6
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends software-properties-common \
+    && add-apt-repository -y ppa:fkrull/deadsnakes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -q -y --no-install-recommends python3.6 python3.6-dev python3-pip python3-setuptools python3-wheel gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# set python 3.5 as the default python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 \
+    && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN pip3 install --upgrade pip requests
+
+# make requests library use the Debian CA bundle (includes Zalando CA)
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+CMD python3
+
+RUN purge.sh

--- a/Dockerfile.36
+++ b/Dockerfile.36
@@ -1,5 +1,4 @@
-#FROM registry.opensource.zalan.do/stups/ubuntu:UPSTREAM
-FROM registry.opensource.zalan.do/stups/ubuntu:16.04-cd33
+FROM registry.opensource.zalan.do/stups/ubuntu:latest
 MAINTAINER Zalando SE
 
 # Install python3.6


### PR DESCRIPTION
Unfortunately python3.6 is not available in Ubuntu 16.04 and we don't have a 16.10 base image so it has to be installed from a ppa.