### PR TITLE
Update to Python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM registry.opensource.zalan.do/stups/ubuntu:UPSTREAM
+FROM registry.opensource.zalan.do/stups/ubuntu:latest
 MAINTAINER Zalando SE
 
-# Install python3.5
+# Install python3.6
 RUN apt-get update \
-    && apt-get install -q -y --no-install-recommends python3.5 python3.5-dev python3-pip python3-setuptools python3-wheel gcc \
+    && apt-get install -y --no-install-recommends software-properties-common \
+    && add-apt-repository -y ppa:fkrull/deadsnakes \
+    && apt-get update \
+    && apt-get install -q -y --no-install-recommends python3.6 python3.6-dev python3-pip python3-setuptools python3-wheel gcc \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-# set python 3.5 as the default python version
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.5 1 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1 \
+# set python 3.6 as the default python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 \
     && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN pip3 install --upgrade pip requests
 

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 Zalando Docker Python Image
 ===========================
 
-This Docker base image contains Python 3.5 and the Zalando CA certificate.
+This Docker base image contains Python 3.6 and the Zalando CA certificate.
 Versions of this image will be immutable, i.e. there is no "latest" tag, but instead version numbers are incremented
 like::
 
-    <PYTHON_VERSION>-<COUNTER> (example: "3.5.0-2")
+    <PYTHON_VERSION>-<COUNTER> (example: "3.6.1-1")
 
 Build the Docker image:
 


### PR DESCRIPTION
It would be great to have Python 3.6 in this image (it's necessary since
it's not available in Ubuntu 16.04 yet), and there are two solutions:

* Install Python 3.6 from ppa (as in this PR)
* Update this image to use Ubuntu 16.10

There was one "stale" [PR](https://github.com/zalando/docker-python/pull/7) in the past about the same, I hope this time we can work it out.