### PR TITLE
new delivery.yaml format

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,4 +1,8 @@
-build_steps:
+version: "2017-09-20"
+pipeline:
+  - id: build
+    type: script
+    commands:
     - desc: 'Install required build software'
       cmd: 'apt-get install -y make git apt-transport-https ca-certificates curl'
     - desc: 'Install Docker'

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,4 +1,8 @@
 version: "2017-09-20"
+dependencies:
+    - id: base
+      type: docker
+      ref: registry.opensource.zalan.do/stups/ubuntu
 pipeline:
   - id: build
     type: script
@@ -9,6 +13,9 @@ pipeline:
       cmd: 'curl -sSL https://delivery.cloud.zalando.com/utils/ensure-docker | sh'
     - desc: 'Build'
       cmd: |
+        # use the resolved Ubuntu base image version
+        echo "Ubuntu base image version: ${DEP_BASE_VERSION}"
+        sed -i "s,:latest,:${DEP_BASE_VERSION}," Dockerfile
         image=python-temp:${CDP_BUILD_VERSION}
         docker build -t $image --squash .
         sed -i "s,UNTESTED,$image,g" Dockerfile.test


### PR DESCRIPTION
Use the most recent format for `delivery.yaml` and also automatically trigger on upstream Ubuntu build.